### PR TITLE
Bug-fix: Linking against json-prolog when building sr-knowrob-plugin.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,5 +20,6 @@ add_library(sr_plugin_knowrob
   src/PluginKnowRob.cpp)
 
 target_link_libraries(sr_plugin_knowrob
+  ${catkin_LIBRARIES}
   sr_plugin_owlexporter
   config++)


### PR DESCRIPTION
Without this fix the plugin will crash at runtime because of an unreferenced symbol from json-prolog.
